### PR TITLE
Feature/demo updates

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,6 +11,7 @@ const onlyUniqueFilter = require('./src/filters/only-unique-filter.js');
 const getUniqueTagsList = require('./src/filters/getUniqueTagsList.js');
 const cssmin = require('./src/filters/css-minify-filter.js');
 const contentUpdatesOfType = require('./src/filters/contentUpdatesOfType')
+const contentUpdatesForDemo = require('./src/filters/contentUpdatesForDemo')
 
 
 // Import transforms
@@ -29,6 +30,7 @@ module.exports = function(config) {
   config.addFilter("onlyUniqueFilter", onlyUniqueFilter);
   config.addFilter("cssmin", cssmin);
   config.addFilter("contentUpdatesOfType",contentUpdatesOfType);
+  config.addFilter("contentUpdatesForDemo", contentUpdatesForDemo);
 
   // Layout aliases
   config.addLayoutAlias('home', 'layouts/home.njk');

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -10,6 +10,7 @@ const w3DateFilter = require('./src/filters/w3-date-filter.js');
 const onlyUniqueFilter = require('./src/filters/only-unique-filter.js');
 const getUniqueTagsList = require('./src/filters/getUniqueTagsList.js');
 const cssmin = require('./src/filters/css-minify-filter.js');
+const contentUpdatesOfType = require('./src/filters/contentUpdatesOfType')
 
 
 // Import transforms
@@ -27,6 +28,7 @@ module.exports = function(config) {
   config.addFilter("getUniqueTagsList", getUniqueTagsList);
   config.addFilter("onlyUniqueFilter", onlyUniqueFilter);
   config.addFilter("cssmin", cssmin);
+  config.addFilter("contentUpdatesOfType",contentUpdatesOfType);
 
   // Layout aliases
   config.addLayoutAlias('home', 'layouts/home.njk');
@@ -67,7 +69,11 @@ module.exports = function(config) {
     ].reverse();
   });
 
-  // config.addCollection('demoTags', getDemosUniqueTags)
+    config.addCollection('contentUpdates', collectionApi => {
+    return [
+      ...collectionApi.getFilteredByGlob('./src/content-updates/*.md')
+    ].reverse();
+  });
 
   config.addCollection('postFeed', collectionApi => {
     return [...collectionApi.getFilteredByGlob('./src/posts/*.md').filter(livePosts)]

--- a/src/_includes/layouts/demo.njk
+++ b/src/_includes/layouts/demo.njk
@@ -7,7 +7,17 @@
 {% if currentDemoContentUpdates.length %}
   <ul>
     {% for item in currentDemoContentUpdates | reverse %}
-      <a href="{{item.url}}">{{item.data.title}}</a>
+      <li>
+        {# This line ↓↓ returns the HTML output (what .md files are compiled into) EXACTLY the way we want it!! ↓↓ #}
+        {{ item.templateContent | truncate(100) | safe }}
+        <a href="{{item.url}}">{{item.data.when}}</a>
+      </li>
     {% endfor %}
   </ul>
 {% endif %}
+
+{# This line ↓↓ returns frontMatter + content in a strange format ↓↓ #}
+{# {% renderFile "./src/content-updates/1.md" %} #}
+
+{# This line ↓↓ returns only the raw content without .md formatting!! ↓↓ #}
+{# {{ item.template.frontMatter.content }} #}

--- a/src/_includes/layouts/demo.njk
+++ b/src/_includes/layouts/demo.njk
@@ -1,0 +1,13 @@
+{% set demoTitle = title %}
+{% set allDemoContentUpdates = collections.contentUpdates | contentUpdatesOfType('demos') %}
+{% set currentDemoContentUpdates = allDemoContentUpdates | contentUpdatesOfType('demos') %}
+
+<h1>{{ demoTitle }}</h1>
+
+{% if currentDemoContentUpdates.length %}
+  <ul>
+    {% for item in currentDemoContentUpdates | reverse %}
+      <a href="{{item.url}}">{{item.data.title}}</a>
+    {% endfor %}
+  </ul>
+{% endif %}

--- a/src/_includes/layouts/demo.njk
+++ b/src/_includes/layouts/demo.njk
@@ -1,15 +1,22 @@
 {% set demoTitle = title %}
-{% set currentDemoUpdates = collections.contentUpdates | contentUpdatesOfType('demos') %}
+{% set allDemoUpdates = collections.contentUpdates | contentUpdatesOfType('demos') %}
+{# Need to figure out how to get content updates only for this specific demo 
+https://www.11ty.dev/docs/languages/nunjucks/#usage-4 
+#}
+{% set currentDemoUpdates = allDemoUpdates | contentUpdatesForDemo('Comparator of Repos') %}
 
 <h1>{{ demoTitle }}</h1>
-
 {% if currentDemoUpdates.length %}
   <ul>
     {% for item in currentDemoUpdates | reverse %}
       <li>
         {# This line ↓↓ returns the HTML output (what .md files are compiled into) EXACTLY the way we want it!! ↓↓ #}
         {{ item.templateContent | truncate(100) | safe }}
-        <a href="{{item.url}}">{{item.data.when}}</a>
+        {% if item.data.date %}
+          <a href="{{item.url}}">
+            <time datetime="{{ item.data.date | w3DateFilter }}" class="dt-published">{{ item.data.date | dateFilter }}</time>
+          </a>
+        {% endif %}
       </li>
     {% endfor %}
   </ul>

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -19,7 +19,7 @@
         {{ content | safe }}
       </div>
       {% if site.enableThirdPartyComments %}
-        <hr />
+        <hr/>
         <aside class="[ post__body ] [ inner-wrapper ] [ pad-bottom-900 text-500 ]">
           {% include "partials/global/third-party-comments.njk" %}
         </aside>

--- a/src/content-updates/1.md
+++ b/src/content-updates/1.md
@@ -1,10 +1,14 @@
 ---
 date: 2022-01-28T12:00:00Z
-tags: []
+tags: [demos]
 belongs_to_content_of_type:
-- demos
+  - demos
 belongs_to_specific_file_or_page:
-- Comparator Of Repos
-
+  - Comparator Of Repos
+permalink: '/content-updates/{{ belongs_to_specific_file_or_page[0] | slugify }}/index.html'
+identifier: '{{demos}}-{{ belongs_to_specific_file_or_page }}-date'
+eleventyComputed:
+  title: 'Update on {{ date | w3DateFilter }}'
 ---
+
 The goal of this pen has been to provide an opportunity to learn how to work with React state, specifically how to "lift" a common part of the state object and use it across multiple child components, and how to decide what should be the minimal amount information that's kept within the state object. It's a work in progress, as it still needs to calculate a score based on sate.

--- a/src/content-updates/1.md
+++ b/src/content-updates/1.md
@@ -1,13 +1,10 @@
 ---
 date: 2022-01-28T12:00:00Z
-tags: [demos]
-camilo: 'camilo'
+tags: []
 belongs_to_content_of_type:
   - demos
 belongs_to_specific_file_or_page:
   - Comparator Of Repos
-permalink: '/content-updates/{{ belongs_to_specific_file_or_page[0] | slugify }}/index.html'
-identifier: '{{demos}}-{{ belongs_to_specific_file_or_page }}-date'
 ---
 
-The goal of this pen has been to provide an opportunity to learn how to work with React state, specifically how to "lift" a common part of the state object and use it across multiple child components, and how to decide what should be the minimal amount information that's kept within the state object. It's a work in progress, as it still needs to calculate a score based on sate.
+The goal of this pen has been to provide an opportunity to learn how to work with React state, specifically how to "lift" a common piece of state and use it across multiple child components, and how to decide what should be the minimal amount information that's kept within the state object. It's a work in progress, as it still needs to calculate a score based on sate.

--- a/src/content-updates/1.md
+++ b/src/content-updates/1.md
@@ -1,14 +1,13 @@
 ---
 date: 2022-01-28T12:00:00Z
 tags: [demos]
+camilo: 'camilo'
 belongs_to_content_of_type:
   - demos
 belongs_to_specific_file_or_page:
   - Comparator Of Repos
 permalink: '/content-updates/{{ belongs_to_specific_file_or_page[0] | slugify }}/index.html'
 identifier: '{{demos}}-{{ belongs_to_specific_file_or_page }}-date'
-eleventyComputed:
-  title: 'Update on {{ date | w3DateFilter }}'
 ---
 
 The goal of this pen has been to provide an opportunity to learn how to work with React state, specifically how to "lift" a common part of the state object and use it across multiple child components, and how to decide what should be the minimal amount information that's kept within the state object. It's a work in progress, as it still needs to calculate a score based on sate.

--- a/src/content-updates/content-updates.11tydata.js
+++ b/src/content-updates/content-updates.11tydata.js
@@ -1,0 +1,5 @@
+module.exports = {
+  eleventyComputed: {
+    title: data => `Updated on ${data.date}`
+  }
+}

--- a/src/content-updates/content-updates.11tydata.js
+++ b/src/content-updates/content-updates.11tydata.js
@@ -1,5 +1,7 @@
 module.exports = {
   eleventyComputed: {
-    title: data => `Updated on ${data.date}`
+    title: data => `${data.page.fileSlug}`,
+    when: data => `Updated on ${data.date}`,
+    permalink: data => `/content-updates/${data.page.fileSlug}/index.html`
   }
 }

--- a/src/content-updates/index.njk
+++ b/src/content-updates/index.njk
@@ -1,0 +1,12 @@
+---
+title: "All Content Updates"
+---
+
+<h1>{{ title }}</h1>
+
+{% set demoContentUpdates = collections.contentUpdates | contentUpdatesOfType('demos') %}
+{% set postContentUpdates = collections.contentUpdates | contentUpdatesOfType('posts') %}
+
+<p>All content updates: {{ collections.contentUpdates.length }}</p>
+<p>Demo content updates: {{ demoContentUpdates.length }}</p>
+<p>Post content updates: {{ postContentUpdates.length }}</p>

--- a/src/demos/comparator-of-repos.md
+++ b/src/demos/comparator-of-repos.md
@@ -3,8 +3,7 @@ title: Comparator Of Repos
 description: Take your favorite repos head-to-head!
 image_url: https://shots.codepen.io/username/pen/MWoMGwj-800.webp?version=1635951846
 tags:
-- react
+  - react
 link: https://codepen.io/jcasensio/full/MWoMGwj
 date: 2022-01-16T15:00:00Z
-
 ---

--- a/src/demos/demos.json
+++ b/src/demos/demos.json
@@ -1,0 +1,3 @@
+{
+  "layout": "layouts/demo.njk"
+}

--- a/src/demos/index.njk
+++ b/src/demos/index.njk
@@ -7,17 +7,18 @@ permalink: '/demos/index.html'
 
 {% set demoList = collections.demos %}
 {% set demoNavItems = demoList | getUniqueTagsList %}
+
 {% set css %}
 {% for item in demoNavItems %}
-      .filter-{{ item }} nav li.{{ item }} a {
-        color: var(--color-accent);
-        border-bottom: solid var(--border);
-      }
+  .filter-{{ item }} nav li.{{ item }} a {
+    color: var(--color-accent);
+    border-bottom: solid var(--border);
+  }
 
-      .filter-{{ item }} ul.list li:not(.{{ item }}) {
-        display: none;
-      }
-    {% endfor %}
+  .filter-{{ item }} ul.list li:not(.{{ item }}) {
+    display: none;
+  }
+{% endfor %}
 {% endset %}
 
 {% block head %}

--- a/src/demos/index.njk
+++ b/src/demos/index.njk
@@ -1,5 +1,6 @@
 ---
 title: 'Demos'
+layout: ''
 permalink: '/demos/index.html'
 ---
 

--- a/src/filters/contentUpdatesForDemo.js
+++ b/src/filters/contentUpdatesForDemo.js
@@ -1,3 +1,3 @@
 module.exports = contentUpdatesForDemo = (collection, contentTypeStr) => {
-  return collection.filter(item => item.data.belongs_to_specific_file_or_page.includes(contentTypeStr));
+  return collection.filter(item => item.data.belongs_to.includes(contentTypeStr));
 }

--- a/src/filters/contentUpdatesForDemo.js
+++ b/src/filters/contentUpdatesForDemo.js
@@ -1,0 +1,3 @@
+module.exports = contentUpdatesForDemo = (collection, contentTypeStr) => {
+  return collection.filter(item => item.data.belongs_to_specific_file_or_page.includes(contentTypeStr));
+}

--- a/src/filters/contentUpdatesOfType.js
+++ b/src/filters/contentUpdatesOfType.js
@@ -1,3 +1,17 @@
 module.exports = contentUpdatesOfType = (collection, contentTypeStr) => {
-  return collection.filter(item => item.data.belongs_to_content_of_type.includes(contentTypeStr));
+  return collection.filter((item) => {
+    const dataObj = item.data;
+    let belongsToContentType = false;
+    let hasTag = false
+    
+    if ('belongs_to_content_of_type' in dataObj && Array.isArray(dataObj.belongs_to_content_of_type)) {
+      belongsToContentType = dataObj.belongs_to_content_of_type.includes(contentTypeStr);
+    }
+    
+    if ('tags' in dataObj && Array.isArray(dataObj.tags)) {
+      hasTag = dataObj.tags.includes(contentTypeStr);
+    }
+    
+    return belongsToContentType || hasTag;
+  });
 }

--- a/src/filters/contentUpdatesOfType.js
+++ b/src/filters/contentUpdatesOfType.js
@@ -1,0 +1,3 @@
+module.exports = contentUpdatesOfType = (collection, contentTypeStr) => {
+  return collection.filter(item => item.data.belongs_to_content_of_type.includes(contentTypeStr));
+}

--- a/src/filters/getUniqueTagsList.js
+++ b/src/filters/getUniqueTagsList.js
@@ -1,9 +1,9 @@
 const onlyUniqueFilter = require('./only-unique-filter');
   
-module.exports = getUniqueTagsList = (collection) => {
+module.exports = getUniqueTagsList = (collectionApi) => {
   let tags = [];
 
-  collection.forEach(item => {
+  collectionApi.forEach(item => {
     tags = [...tags, ...item.data.tags]
   })
   return tags.filter(onlyUniqueFilter)


### PR DESCRIPTION
The goal is to allow for updates to be rendered for any piece of content, starting with any markdown file that's part of a collection like **`posts`** or **`demos`**

There are a number of ways to go about this. One route that we've been testing with involves using filters to find content updates from the default 11ty collections that match the title of a given piece of content.

Another idea is to create a json file that we can consume on build. We would then use something like eleventyComputed or another way to call a JavaScript function or access a JavaScript data file to get the content update that match a particular piece of content.

**Super helpful links on how to get only the content from a file and how to work with data**
- https://11ty.rocks/posts/using-template-content-as-data/
- https://github.com/11ty/eleventy/issues/1206#issue-623473473
- https://benmyers.dev/blog/eleventy-data-cascade/


Some TODO ideas:

- Figure out how to render the Markdown content of a Markdown file (i.e.: not the front matter of a file but the actual "words" in the content)
  - One idea is to use the `renderFile` or `renderTemplate` [shortcodes]( https://www.11ty.dev/docs/plugins/render/).
  - Similarly, creating a custom shortcode might be the way to go. This example renders HTML content in Markdown. We, basically, want to figure out how to render Markdown within Markdown: https://www.webstoemp.com/blog/modular-code-nunjucks-eleventy/
  - What about adding an excerpt to content and access it via `page.excerpt`? https://www.11ty.dev/docs/data-frontmatter-customize/#example-parse-excerpts-from-content

**Working with Front Matter**
 - Front Matter, what to do? (Read with Professor Dumbledore's voice) https://www.11ty.dev/docs/data-deep-merge/#using-the-override-prefix
- https://www.11ty.dev/docs/data-deep-merge/#using-the-override-prefix